### PR TITLE
fix: 꿀팁 게시판 페이지네이션 에러 수정

### DIFF
--- a/src/app/honeytips/_components/PostList.tsx
+++ b/src/app/honeytips/_components/PostList.tsx
@@ -27,6 +27,19 @@ const PostList = () => {
 
   const router = useRouter();
 
+  // 페이지네이션
+  const {
+    currentItems: currentPosts,
+    currentPage,
+    setCurrentPage,
+    totalPages,
+    startButtonIndex,
+    maxButtonsToShow,
+    nextPage,
+    prevPage,
+    goToPage,
+  } = usePagination(filteredPosts, 20);
+
   // 마운트 시 전체 포스트 불러오기
   useEffect(() => {
     const fetchPosts = async () => {
@@ -87,17 +100,10 @@ const PostList = () => {
     }
   };
 
-  // 페이지네이션
-  const {
-    currentItems: currentPosts,
-    currentPage,
-    totalPages,
-    startButtonIndex,
-    maxButtonsToShow,
-    nextPage,
-    prevPage,
-    goToPage,
-  } = usePagination(filteredPosts, 20);
+  const handleClickCategory = (category: string) => {
+    setSelectedCategory(category);
+    setCurrentPage(1);
+  };
 
   return (
     <section className="container mx-auto">
@@ -111,7 +117,7 @@ const PostList = () => {
                 ? "text-base-800"
                 : "hover:text-base-800",
             )}
-            onClick={() => setSelectedCategory(category)}
+            onClick={() => handleClickCategory(category)}
           >
             {category}
             {selectedCategory === category && (

--- a/src/app/hooks/usePagination.tsx
+++ b/src/app/hooks/usePagination.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 export type PaginationHook<T> = {
   currentItems: T[];
   currentPage: number;
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
   totalPages: number;
   startButtonIndex: number;
   maxButtonsToShow: number;
@@ -32,9 +33,12 @@ const usePagination = <T,>(
   const prevPage = () => setCurrentPage((prev) => Math.max(prev - 1, 1));
   const goToPage = (page: number) => setCurrentPage(page);
 
+  console.log('currentPage', currentPage)
+
   return {
     currentItems,
     currentPage,
+    setCurrentPage,
     totalPages,
     startButtonIndex,
     maxButtonsToShow,


### PR DESCRIPTION
## Title

- 꿀팁게시판 에러 수정

## Changes

- 꿀팁 게시판 메인에서 페이지 2로 이동 후 다른 카테고리 클릭 시, 포스트 없음으로 뜨는 에러 수정

## PR 생성 날짜

- 2025.01.14

## CheckList

- [X] 절대 경로로 작성했습니다.
- [X] 화살표 함수로 함수 선언했습니다.
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 타입 추론이 되는 경우에도 명시적으로 타입 선언했습니다.
