### PR TITLE
refactor: 페이지네이션 공통 컴포넌트로 분리

### DIFF
--- a/src/app/hooks/usePagination.tsx
+++ b/src/app/hooks/usePagination.tsx
@@ -17,9 +17,10 @@ const usePagination = <T,>(
   itemsPerPage: number,
 ): PaginationHook<T> => {
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const totalPages = Math.ceil(items.length / itemsPerPage);
+  const itemsArray = Array.isArray(items) ? items : [];
+  const totalPages = Math.ceil(itemsArray.length / itemsPerPage);
 
-  const currentItems = items.slice(
+  const currentItems = itemsArray.slice(
     (currentPage - 1) * itemsPerPage,
     currentPage * itemsPerPage,
   );
@@ -32,8 +33,6 @@ const usePagination = <T,>(
     setCurrentPage((prev) => Math.min(prev + 1, totalPages));
   const prevPage = () => setCurrentPage((prev) => Math.max(prev - 1, 1));
   const goToPage = (page: number) => setCurrentPage(page);
-
-  console.log('currentPage', currentPage)
 
   return {
     currentItems,

--- a/src/app/policy/_components/PolicyCont.tsx
+++ b/src/app/policy/_components/PolicyCont.tsx
@@ -3,9 +3,9 @@
 import usePagination from "@/app/hooks/usePagination";
 import { getPolicies } from "@/app/policy/_actions/getPolicies";
 import PolicyFilter from "@/app/policy/_components/PolicyFilter";
-import PolicyPagination from "@/app/policy/_components/PolicyPagination";
 import PolicyResult from "@/app/policy/_components/PolicyResult";
 import { REGION_CODES } from "@/app/policy/_constants/region";
+import Pagination from "@/components/common/Pagination";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -31,10 +31,11 @@ const PolicyCont = () => {
     queryKey: ["policies"],
     queryFn: async () => {
       const regionCode = REGION_CODES[filters.region];
-      return getPolicies({
+      const response = await getPolicies({
         polyRlmCd: filters.field,
         srchPolyBizSecd: regionCode,
       });
+      return Array.isArray(response) ? response : [response];
     },
     enabled: !!filters.region && !!filters.field,
     initialData: null,
@@ -76,22 +77,23 @@ const PolicyCont = () => {
         onFieldChange={(field) => handleFilterChange("field", field)}
         onSearch={handleSearch}
       />
-      <PolicyResult
-        error={error}
-        isLoading={isLoading || isRefetching}
-        policyData={currentPolicyData}
-      />
-      {policyData && policyData.length > 0 && (
-        <PolicyPagination
-          isLoading={isLoading || isRefetching}
-          currentPage={currentPage}
-          totalPages={totalPages}
-          startButtonIndex={startButtonIndex}
-          maxButtonsToShow={maxButtonsToShow}
-          prevPage={prevPage}
-          nextPage={nextPage}
-          goToPage={goToPage}
-        />
+      {isLoading || isRefetching ? (
+        <p>로딩중...</p> //TODO: 로딩 스피너 추가
+      ) : (
+        <>
+          <PolicyResult error={error} policyData={currentPolicyData} />
+          {policyData && policyData.length > 0 && (
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              startButtonIndex={startButtonIndex}
+              maxButtonsToShow={maxButtonsToShow}
+              onNextPage={nextPage}
+              onPrevPage={prevPage}
+              onGoToPage={goToPage}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/src/app/policy/_components/PolicyResult.tsx
+++ b/src/app/policy/_components/PolicyResult.tsx
@@ -4,19 +4,14 @@ import { useState } from "react";
 
 type PolicyResultProps = {
   error: Error | null;
-  isLoading: boolean;
   policyData: PolicyData[] | PolicyData | null;
 };
 
-const PolicyResult = ({ error, isLoading, policyData }: PolicyResultProps) => {
+const PolicyResult = ({ error, policyData }: PolicyResultProps) => {
   const [isLoadingPage, setIsLoadingPage] = useState(false);
 
   if (error instanceof Error) {
     return <div className="text-red-500">에러: {error.message}</div>; //TODO: 에러 메시지 추가
-  }
-
-  if (isLoading) {
-    return <div>조회 중...</div>; //TODO: 로딩 스피너 추가
   }
 
   if (policyData === null) {

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,32 +1,18 @@
-type PolicyPaginationProps = {
-  isLoading: boolean;
-  currentPage: number;
-  totalPages: number;
-  startButtonIndex: number;
-  maxButtonsToShow: number;
-  prevPage: () => void;
-  nextPage: () => void;
-  goToPage: (page: number) => void;
-};
+import type { PaginationProps } from "@/types/pagination.types";
 
-const PolicyPagination = ({
-  isLoading,
+const Pagination = ({
   currentPage,
   totalPages,
   startButtonIndex,
   maxButtonsToShow,
-  prevPage,
-  nextPage,
-  goToPage,
-}: PolicyPaginationProps) => {
-  if (isLoading) {
-    return null; 
-  }
-
+  onNextPage,
+  onPrevPage,
+  onGoToPage,
+}: PaginationProps) => {
   return (
     <div className="mt-4 flex items-center justify-center">
       <button
-        onClick={prevPage}
+        onClick={onPrevPage}
         disabled={currentPage === 1}
         className="rounded px-4 py-2 text-base-500"
       >
@@ -38,7 +24,7 @@ const PolicyPagination = ({
       }).map((_, index) => (
         <button
           key={startButtonIndex + index}
-          onClick={() => goToPage(startButtonIndex + index + 1)}
+          onClick={() => onGoToPage(startButtonIndex + index + 1)}
           className={`mx-1 rounded px-3 py-2 ${
             currentPage === startButtonIndex + index + 1
               ? "font-bold text-base-800"
@@ -50,7 +36,7 @@ const PolicyPagination = ({
       ))}
 
       <button
-        onClick={nextPage}
+        onClick={onNextPage}
         disabled={currentPage === totalPages}
         className="rounded px-4 py-2 text-base-500"
       >
@@ -60,4 +46,4 @@ const PolicyPagination = ({
   );
 };
 
-export default PolicyPagination;
+export default Pagination;

--- a/src/types/pagination.types.ts
+++ b/src/types/pagination.types.ts
@@ -1,0 +1,9 @@
+export type PaginationProps = {
+  currentPage: number;
+  totalPages: number;
+  startButtonIndex: number;
+  maxButtonsToShow: number;
+  onNextPage: () => void;
+  onPrevPage: () => void;
+  onGoToPage: (page: number) => void;
+}


### PR DESCRIPTION
## Title

- 페이지네이션 공통 컴포넌트로 분리

## Changes

- 페이지네이션 ui부분을 공통 컴포넌트로 분리(훅도 따로 import해서 쓸것!)
- 페이지네이션 타입 선언

## PR 생성 날짜

- 2025.01.14

## CheckList

- [X] 절대 경로로 작성했습니다.
- [X] 화살표 함수로 함수 선언했습니다.
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 타입 추론이 되는 경우에도 명시적으로 타입 선언했습니다.
